### PR TITLE
Change the order of checking the arguments in the example code. (develop)

### DIFF
--- a/examples/gtc_final_report.py
+++ b/examples/gtc_final_report.py
@@ -13,14 +13,14 @@ parser.add_argument("output_file", help="Location to write report")
 
 args = parser.parse_args()
 
+if os.path.isfile(args.output_file):
+    sys.stderr.write("Output file already exists, please delete and re-run\n")
+    sys.exit(-1)
+
 try:
     manifest = BeadPoolManifest(args.manifest)
 except:
     sys.stderr.write("Failed to read data from manifest\n")
-    sys.exit(-1)
-
-if os.path.isfile(args.output_file):
-    sys.stderr.write("Output file already exists, please delete and re-run\n")
     sys.exit(-1)
 
 with open(args.output_file, "w") as output_handle:


### PR DESCRIPTION
Thank you for commenting. Now it is on the develop branch.

----------------------------------------------------------------------------------------------
I just changed the order of the example code.
Current code checks a manifest file first and then it checks whether a output file exists.
Creating a manifest object takes a long time so if the output file already exists, a user wastes their time.
I know it is just a example code and it is a really small thing but I think it can be better for the users.