### PR TITLE
Fix for LocusAggregate.aggregate_samples

### DIFF
--- a/module/LocusAggregate.py
+++ b/module/LocusAggregate.py
@@ -193,8 +193,8 @@ class LocusAggregate(object):
         for loci_group in LocusAggregate.group_loci(loci, loci_batch_size):
 
             # read in the buffer for this group of loci
-            buffer = LocusAggregate.load_buffer(
-                samples, loci_group[0], loci_group[-1] - loci_group[0] + 1, normalization_lookups)
+            buffer = list(LocusAggregate.load_buffer(
+                samples, loci_group[0], loci_group[-1] - loci_group[0] + 1, normalization_lookups))
 
             # generate corresponding locus aggregates
             aggregates = map(GenerateLocusAggregate(


### PR DESCRIPTION
Copy `buffer` to list so it can be consumed multiple times, as LocusAggregate's are generated.

More details described in https://github.com/Illumina/BeadArrayFiles/issues/31